### PR TITLE
fixes #66 footer stacking, added buttons, fixed aesthetics on about page

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -37,7 +37,7 @@ body {
   color: rgb(254,246,234);
   color: rgba(254,246,234,.8);
 }
-.footmrgn {
+.footer img {
   margin-right:5px;
   margin-bottom:5px;
 }
@@ -71,7 +71,7 @@ body {
   color: #362F35;
 }
 
-.foottop {
+.footer .fa {
   margin-top: 3px;
 }
 

--- a/css/main.css
+++ b/css/main.css
@@ -37,6 +37,10 @@ body {
   color: rgb(254,246,234);
   color: rgba(254,246,234,.8);
 }
+.footmrgn {
+  margin-right:5px;
+  margin-bottom:5px;
+}
 
 .blip {
   margin-top: 60px;
@@ -65,6 +69,10 @@ body {
 .whowhatwhy {
   padding-top: 2em;
   color: #362F35;
+}
+
+.foottop {
+  margin-top: 3px;
 }
 
 .img-thumbnail {

--- a/views/about.lavender
+++ b/views/about.lavender
@@ -30,7 +30,7 @@ block content
             | of daft labs, whose favorite color is purple. It was his wife who made the connection
             | between the name Lavender and the budding programming language, and thus the
             | name stuck.
-          a.btn.btn-default(href='https://github.com/golavender/lavender', target='_blank') Fork Us.
+          a.btn.btn-home(href='https://github.com/golavender/lavender', target='_blank') Fork Us.
   .container
     .row
       .col-md-8.col-md-offset-2.about.img-rounded
@@ -42,4 +42,4 @@ block content
             a(href='http://daftlabs.com/', target='_blank') daft labs
             |  was founded in 2013, bringing together a hodge podge
             | team of front and back end developers.  
-          a.btn.btn-default(href='http://www.daftlabs.com', target='_blank') Come Visit Us.
+          a.btn.btn-home(href='http://www.daftlabs.com', target='_blank') Come Visit Us.

--- a/views/layouts/default.lavender
+++ b/views/layouts/default.lavender
@@ -22,11 +22,14 @@ head
   meta(name='msapplication-TileColor', content='#cdb4cc')
   meta(name='msapplication-TileImage', content='/img/favicons/mstile-144x144.png')
   meta(name='theme-color', content='#796878')
-  link(rel='stylesheet', href='http://fonts.googleapis.com/css?family=Oswald:400,600|Lato:300,700|Special+Elite')
+  link(rel='stylesheet',
+    href='http://fonts.googleapis.com/css?family=Oswald:400,600|Lato:300,700|Special+Elite'
+  )
   link(rel='stylesheet', 
     href='http://maxcdn.bootstrapcdn.com/bootstrap/3.3.1/css/bootstrap.min.css')
   link(rel='stylesheet', 
-    href='http://maxcdn.bootstrapcdn.com/font-awesome/4.3.0/css/font-awesome.min.css')
+    href='http://maxcdn.bootstrapcdn.com/font-awesome/4.3.0/css/font-awesome.min.css'
+  )
   link(rel='stylesheet', href='css/prism.css')
   link(rel='stylesheet', href='css/main.css')
   script(src='js/prism.js')
@@ -87,9 +90,17 @@ body
 
 footer.footer
   .container-fluid
-    .col-md-1
-      img(src='/img/lavender-logo-2015.png', height='40', width='40')
-    .col-md-2
+      img.pull-left.footmrgn(
+        src='/img/lavender-logo-2015.png',
+        height='35',
+        width='35',
+      ) 
+      a(href='https://www.facebook.com/daftlabs', target='_blank')
+        i.pull-right.foottop.fa.fa-facebook-square.fa-2x
+      a(href='https://www.github.com/daftlabs', target='_blank')
+        i.pull-right.foottop.fa.fa-github-square.fa-2x
+      a(href='https://www.twitter.com/daftlabs', target='_blank')
+        i.pull-right.foottop.fa.fa-twitter-square.fa-2x
       h6 
         a(href='http://www.daftlabs.com', target='_blank') 2014-2015 daft labs, inc.
-        | enjoy.
+        | enjoy. 

--- a/views/layouts/default.lavender
+++ b/views/layouts/default.lavender
@@ -22,12 +22,15 @@ head
   meta(name='msapplication-TileColor', content='#cdb4cc')
   meta(name='msapplication-TileImage', content='/img/favicons/mstile-144x144.png')
   meta(name='theme-color', content='#796878')
-  link(rel='stylesheet',
+  link(
+    rel='stylesheet',
     href='http://fonts.googleapis.com/css?family=Oswald:400,600|Lato:300,700|Special+Elite'
   )
-  link(rel='stylesheet', 
+  link(
+    rel='stylesheet', 
     href='http://maxcdn.bootstrapcdn.com/bootstrap/3.3.1/css/bootstrap.min.css')
-  link(rel='stylesheet', 
+  link(
+    rel='stylesheet', 
     href='http://maxcdn.bootstrapcdn.com/font-awesome/4.3.0/css/font-awesome.min.css'
   )
   link(rel='stylesheet', href='css/prism.css')

--- a/views/layouts/default.lavender
+++ b/views/layouts/default.lavender
@@ -90,17 +90,17 @@ body
 
 footer.footer
   .container-fluid
-      img.pull-left.footmrgn(
+      img.pull-left(
         src='/img/lavender-logo-2015.png',
         height='35',
         width='35',
       ) 
       a(href='https://www.facebook.com/daftlabs', target='_blank')
-        i.pull-right.foottop.fa.fa-facebook-square.fa-2x
+        i.pull-right.fa.fa-facebook-square.fa-2x
       a(href='https://www.github.com/daftlabs', target='_blank')
-        i.pull-right.foottop.fa.fa-github-square.fa-2x
+        i.pull-right.fa.fa-github-square.fa-2x
       a(href='https://www.twitter.com/daftlabs', target='_blank')
-        i.pull-right.foottop.fa.fa-twitter-square.fa-2x
+        i.pull-right.fa.fa-twitter-square.fa-2x
       h6 
         a(href='http://www.daftlabs.com', target='_blank') 2014-2015 daft labs, inc.
         | enjoy. 


### PR DESCRIPTION
Fixes #66 .

http://screencast.com/t/nVCsDknnfsTo
Updated footer also has links to the daft labs facebook, github and twitter to allow for social media contacts.

Also updated buttons on about page to match the button on the home page in pull request #65 .
