### PR TITLE
fixes #77, fixes #78, fixes #79 - prism markup tweaks

### DIFF
--- a/css/prism.css
+++ b/css/prism.css
@@ -76,7 +76,6 @@ pre[class*="language-"] {
 
 .token.selector,
 .token.attr-name,
-.token.string,
 .token.char,
 .token.builtin,
 .token.inserted {
@@ -93,7 +92,8 @@ pre[class*="language-"] {
 }
 
 .token.atrule,
-.token.attr-value {
+.token.attr-value,
+.token.string {
 	color: #e6db74;
 }
 

--- a/views/download.lavender
+++ b/views/download.lavender
@@ -61,7 +61,7 @@ block content
           | Once you have installed and included lavender, the only required
           | configuration is to tell lavender where the views directory is.
           pre
-            code.language-jade.
+            code.language-markup.
               Lavender::config(array(
 
               /*

--- a/views/guide.lavender
+++ b/views/guide.lavender
@@ -394,7 +394,7 @@ block content
         pre
           code.language-jade.
             p
-              a(href=&#39;/some/place&#39;)- click here for some cool stuff.
+              a(href=&#39;/some/place&#39;)- click here f&ocy;r some cool stuff.
               | |.
         | Automagic whitespace management is hard and subject to change.
         h3#helpers Helpers


### PR DESCRIPTION
Fixes #77 , Fixes #78 , Fixes #79 . All Prism tweaks to make the code more friendly to viewers.

http://screencast.com/t/ElMOyyHJD
Strings now match from markup to Lavender.

Small tweaks (certain words highlighted when they should not have been) have also been done.
